### PR TITLE
Change `npm -i` to `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 ## Installation
 
 ```bash
-npm -i
+npm install
 npm start
 ```


### PR DESCRIPTION
`npm -i` is an invalid command entirely, it is meant to be `npm i` or `npm install`. `npm install` is much more clear, and not that hard to type.